### PR TITLE
Disable slurm shutdown_soon

### DIFF
--- a/tssep_data/eval/run.py
+++ b/tssep_data/eval/run.py
@@ -253,5 +253,5 @@ if __name__ == '__main__':
     print(shlex.join(psutil.Process().cmdline()))
     ex.run_commandline()
 
-    from tssep_data.util.slurm import shutdown_soon
-    shutdown_soon()  # Sometimes the Job gets stuck.
+    # from tssep_data.util.slurm import shutdown_soon
+    # shutdown_soon()  # Sometimes the Job gets stuck.


### PR DESCRIPTION
In my environment, the eval code sometimes got stuck and didn't finish, even though it passed the last line of the code.
I still don't know why and recently it didn't happen.
Since the `shutdown_soon` code prints a Warning to the stdout, that can be confusing
(`SLURM shutdown_soon failed, i.e. kept TimeLimit of SLURM JOB (if its a slurm job). Reason: Missing SLURM_JOBID in env.`), disable that code with this PR.